### PR TITLE
Fix money representation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 A tiny Java prototype that explores **type-safe FX conversions** using *reified* currency types.
 
-Instead of representing money as `(amount, "EUR")` and hoping you don’t accidentally add EUR to USD or apply the wrong FX rate, `typesafe-fx` models:
+Instead of representing money as `(BigDecimal, Currency)` and hoping you don’t accidentally add EUR to USD or apply the wrong FX rate, `typesafe-fx` models:
 
 - `ReifiedCurrency` - a type-safe representation of a currency
 - `MoneyAmount<EUR>` - money *in* a specific currency type


### PR DESCRIPTION
Updated the representation of money in the documentation to use 'BigDecimal' and 'Currency'.